### PR TITLE
Resized all cards in The Learning Crisis to same height

### DIFF
--- a/src/components/landing/ProblemSection.tsx
+++ b/src/components/landing/ProblemSection.tsx
@@ -59,7 +59,7 @@ export default function ProblemSection() {
               className="relative group"
             >
               <div className="absolute -inset-0.5 bg-gradient-to-r from-red-600 to-orange-600 rounded-lg blur opacity-25 group-hover:opacity-50 transition duration-1000 group-hover:duration-200" />
-              <div className="relative bg-card p-8 rounded-lg border border-border">
+              <div className="relative bg-card p-8 rounded-lg border border-border h-[220px] flex flex-col justify-between">
                 <div className="flex items-center mb-4">
                   <div className="p-3 bg-red-100 dark:bg-red-900/20 rounded-lg mr-4">
                     <problem.icon className="h-6 w-6 text-red-600" />


### PR DESCRIPTION
## Description

Resized all cards in The Learning Crisis to same height

Fixes #174 

## Type of change

- [x] Bug fix
- [ ] New feature

## Screenshots / Video

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c1afd870-ebb0-4045-ad0d-280b3ba3eb76" />

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
